### PR TITLE
Fix 500 from main screen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 OLDSITE/
+vicav_*
 
 # ide
 .idea

--- a/xslt/vicavTexts.xslt
+++ b/xslt/vicavTexts.xslt
@@ -1,7 +1,7 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
   xmlns="http://www.w3.org/1999/xhtml" xmlns:tei="http://www.tei-c.org/ns/1.0" version="2.0">
 
-    <xsl:output method="xhtml" encoding="UTF-8"/>
+  <xsl:output method="html" encoding="UTF-8"/>
   <!-- the path under which images are served frome the webapplication. The XQuery function that handles such requests is defined in http.xqm -->
   <xsl:param name="param-images-base-path">images</xsl:param>
   <!-- we make sure that $images-base-path always has a trailing slash -->


### PR DESCRIPTION
I was getting an error when visiting the application home page on a local install:

ERROR:  'file:///home/zabraham/Applications/basex/webapp/vicav-app/xslt/vicavTexts.xslt: line 1: The method attribute of an <xsl:output> element had the value 'xhtml'.  The value must be one of 'xml', 'html', 'text', or qname-but-not-ncname'
FATAL ERROR:  'file:///home/zabraham/Applications/basex/webapp/vicav-app/xslt/vicavTexts.xslt: line 1: The method attribute of an <xsl:output> element had the value 'xhtml'.  The value must be one of 'xml', 'html', 'text', or qname-but-not-ncname'
