### PR TITLE
Heading generation only if TEI does not explicitly state them

### DIFF
--- a/xslt/profile_01.xslt
+++ b/xslt/profile_01.xslt
@@ -92,16 +92,19 @@
             <br/>
         </div>
     </xsl:template>
+
+    <xsl:template match="tei:div[@type='typology']">
+        <div class="h3ProfileTypology">Typology</div>
+        <table class="tbProfile">
+            <tr><td colspan="2" class="tdProfileTableRight"><xsl:value-of select="tei:p[1]"/></td></tr>
+            <tr><td colspan="2" class="tdProfileTableRight"><xsl:value-of select="tei:p[2]"/></td></tr>
+        </table>   
+    </xsl:template>
+
+    <xsl:template match="tei:div[@type='positioning']"/>
     
-    <xsl:template match="tei:div">
+    <xsl:template match="tei:div[@type and not(./tei:head)]">
         <xsl:choose>
-            <xsl:when test="@type='typology'">
-                <div class="h3ProfileTypology">Typology</div>
-                <table class="tbProfile">
-                    <tr><td colspan="2" class="tdProfileTableRight"><xsl:value-of select="tei:p[1]"/></td></tr>
-                    <tr><td colspan="2" class="tdProfileTableRight"><xsl:value-of select="tei:p[2]"/></td></tr>
-                </table>                    
-            </xsl:when>
             <xsl:when test="@type='lingFeatures'">
                 <div class="h3Profile">Linguistic Features</div>
                 <xsl:apply-templates/>
@@ -136,7 +139,12 @@
             </xsl:when>
         </xsl:choose>
     </xsl:template>
-
+    
+    <xsl:template match="tei:div[@type and @type!='typology' and ./tei:head]/tei:head">
+        <div class="h3Profile"><xsl:value-of select="."/></div>
+    </xsl:template>
+    
+    <xsl:template match="tei:div[not(@type)]" />
     <xsl:template match="tei:hi">
         <xsl:choose>
             <xsl:when test="@rendition='#u'"><span style="text-decoration: underline;"><xsl:apply-templates/></span></xsl:when>


### PR DESCRIPTION
The new profile docx2tei which we use for tunocent outputs <head> tags for main divisions so automatic heading generation should not create duplicate headings.

Manual test (a TUNOCENT page and an older page both work:ing as intended
![Screenshot from 2019-10-31 14-06-44](https://user-images.githubusercontent.com/445895/67949330-d325d580-fbe7-11e9-9977-8fb05680a614.png)
