### PR TITLE
Display spaces around word tokens without internal whitespace

### DIFF
--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -54,7 +54,7 @@
                                 <xsl:variable name="wordform" select="tei:fs/tei:f[@name='wordform']"/>
                                 <xsl:message select="$wordform"></xsl:message>
                                 <xsl:choose>
-                                    <xsl:when test="not(matches($wordform, '^[„“-]$')) and not(matches(following-sibling::tei:w[1]/tei:fs/tei:f[@name='wordform'], '^(\W)$'))">
+                                    <xsl:when test="not(matches($wordform, '^[„-]$')) and not(matches(following-sibling::tei:w[1]/tei:fs/tei:f[@name='wordform'], '^\W+$'))">
                                         <xsl:value-of select="replace($wordform, '[\s&#160;]+$', '')"/>
                                         <xsl:value-of select="' '" />
                                     </xsl:when>

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -54,7 +54,7 @@
                                 <xsl:variable name="wordform" select="tei:fs/tei:f[@name='wordform']"/>
                                 <xsl:message select="$wordform"></xsl:message>
                                 <xsl:choose>
-                                    <xsl:when test="not($wordform = '-') and not(matches(following-sibling::tei:w[1]/tei:fs/tei:f[@name='wordform'], '^(-|\.|\?|!)$'))">
+                                    <xsl:when test="not(matches($wordform, '^[„“-]$')) and not(matches(following-sibling::tei:w[1]/tei:fs/tei:f[@name='wordform'], '^(\W)$'))">
                                         <xsl:value-of select="replace($wordform, '[\s&#160;]+$', '')"/>
                                         <xsl:value-of select="' '" />
                                     </xsl:when>

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -1,41 +1,41 @@
 <xsl:stylesheet 
-   xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
-   xmlns="http://www.w3.org/1999/xhtml" 
-   xmlns:tei="http://www.tei-c.org/ns/1.0"
-   version="2.0">
-   
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform" 
+    xmlns="http://www.w3.org/1999/xhtml" 
+    xmlns:tei="http://www.tei-c.org/ns/1.0"
+    version="2.0">
+    
     <xsl:output method="html"/>
     <xsl:template match="/">
         <div>                       
             <!-- <div class="h2Profile"> -->
-                <table class="tbHeader">
-                    <tr><td><h2><xsl:value-of select="//tei:head"/></h2></td><td class="tdTeiLink">{teiLink}</td></tr>
-                </table>            
-                
+            <table class="tbHeader">
+                <tr><td><h2><xsl:value-of select="//tei:head"/></h2></td><td class="tdTeiLink">{teiLink}</td></tr>
+            </table>            
+            
             <!-- </div> -->
             
             <p>By&#160;<i><xsl:value-of select="//tei:author"/>
                 <xsl:if test="//tei:publicationStmt/tei:date">&#160;(<xsl:value-of select="//tei:publicationStmt/tei:date"/>)</xsl:if>
             </i></p>
-        
+            
             <xsl:if test="string-length(//tei:teiHeader/tei:profileDesc/tei:particDesc/tei:p[1])&gt;0">
                 <xsl:for-each select="//tei:teiHeader/tei:profileDesc/tei:particDesc/tei:p">
                     <xsl:apply-templates/>
                 </xsl:for-each>
                 <hr/>
             </xsl:if>
-        
+            
             <xsl:for-each select="//tei:div[@type='sampleText']/tei:p/tei:s | //tei:div[@type='corpusText']/tei:u">
                 <span class="spSentence">
                     <span class="sample-text-tooltip" data-html="true" data-toggle="tooltip" data-placement="top">
-                    
+                        
                         <xsl:attribute name="title">                    
                             <xsl:variable name="nn" select="@n"/>
                             <xsl:value-of select="//tei:s[@type='translationSentence'][@n=$nn] | //tei:div[@type='dvTranslations']/tei:u[@n=$nn]"/>
                         </xsl:attribute>
                         <i class="fa fa-commenting-o" aria-hidden="true"></i>
                     </span>
-                
+                    
                     <xsl:for-each select="tei:w | tei:c | tei:seg">
                         <!-- <span >
                             <xsl:attribute name="onmouseover">omi('')</xsl:attribute>
@@ -43,20 +43,32 @@
                         
                         </span>
                          -->
-                    
+                        
                         <span class="sample-text-tooltip" data-html="true" data-toggle="tooltip" data-placement="top">
                             <xsl:attribute name="title">
                                 <xsl:if test="string-length(tei:fs/tei:f[@name='pos'])&gt;0">&lt;span class="spPos"&gt;POS:&lt;/span&gt;&#160;<xsl:value-of select="tei:fs/tei:f[@name='pos']"/>&lt;br/&gt;</xsl:if>
                                 <xsl:if test="string-length(tei:fs/tei:f[@name='lemma'])&gt;0">&lt;span class="spLemma"&gt;Lemma:&lt;/span&gt;&#160;<xsl:value-of select="tei:fs/tei:f[@name='lemma']"/>&lt;br/&gt;</xsl:if>                            
                                 <xsl:if test="string-length(tei:fs/tei:f[@name='translation'])&gt;0">&lt;span class="spTrans"&gt;English:&lt;/span&gt;&#160;<xsl:value-of select="tei:fs/tei:f[@name='translation']"/></xsl:if>                                                        
                             </xsl:attribute>
-                            <xsl:if test="name()='w'"><xsl:value-of select="tei:fs/tei:f[@name='wordform']"/></xsl:if>
+                            <xsl:if test="name()='w'">
+                                <xsl:variable name="wordform" select="tei:fs/tei:f[@name='wordform']"/>
+                                <xsl:message select="$wordform"></xsl:message>
+                                <xsl:choose>
+                                    <xsl:when test="not($wordform = '-') and not(matches(following-sibling::tei:w[1]/tei:fs/tei:f[@name='wordform'], '^(-|\.|\?|!)$'))">
+                                        <xsl:value-of select="replace($wordform, '[\s&#160;]+$', '')"/>
+                                        <xsl:value-of select="' '" />
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="replace($wordform, '[\s&#160;]+$', '')"/>
+                                    </xsl:otherwise>
+                                </xsl:choose> 
+                            </xsl:if>
                         </span>
-                    
+                        
                         <xsl:if test="name()='c'">
                             <xsl:value-of select="."/>
                         </xsl:if>
-                    
+                        
                         <xsl:if test="name()='seg'">
                             <xsl:value-of select="."/>
                         </xsl:if>               
@@ -65,6 +77,8 @@
             </xsl:for-each>
         </div> 
     </xsl:template>
+    
+    
     
     
 </xsl:stylesheet>


### PR DESCRIPTION
Fix and unify space handling for VICAV sample texts.

The problem is that current  texts have extra spaces attached to the word forms in TEI, which is not very semantic. When I generate a new Tunocent sample text wchich doesnt have these extra spaces, the words are not diaplayed correctly. Thus, I'm trimming the spaces and nbspaces from the resulting word spans and re-adding them across words, unless they are followed by - or punctuation.

Resulting two texts, one is old with spaces in TEI code (MSA), the left is a new, correctly tokenized version.
 
![Screenshot from 2019-11-15 13-08-18](https://user-images.githubusercontent.com/445895/68942676-77437b00-07a9-11ea-8506-5a46b4c1ab45.png)
