### PR TITLE
Phrases should work as well

### DIFF
--- a/cypress/integration/ling_features_spec.js
+++ b/cypress/integration/ling_features_spec.js
@@ -33,14 +33,22 @@ describe('Features Comparison', function() {
 					});
 				});
 			});
+		})
+    });
 
-	    	cy.fixture('api/lingfeatures_Test_body.xml').then(tunisBody => {
-			    cy.request('http://localhost:8984/vicav/profile?coll=vicav_lingfeatures&id=ling_features_test&xslt=features_01.xslt').as('ling_features_test')
-			    cy.get('@ling_features_test').then(response => {
-			    	expect(response.body.replace(/\s*(\r\n|\n|\r)\s*/gm, '')).to.eq(tunisBody.replace(/\s*(\r\n|\n|\r)\s*/gm, ''))
-			    })
-	    	})
-
+    it('should support phrases', function() {
+		cy.visit('http://localhost:8984/vicav/#map=[biblMarkers,_features_,]')
+		cy.get('button.navbar-toggler').click().then(() => {
+			cy.contains('Feature Lists').click().then(() => {
+				cy.contains('Cross-examine the VICAV Feature Lists').scrollIntoView().click().then(() => {
+					cy.contains('how?').click().then(() => {
+						cy.contains('Ahwaz')
+						cy.contains('Baghdad')
+						cy.contains('šlōn ək? / šlōnəč? (f.) – zīən. / zīəna.')
+						cy.contains('(How are you (m./f.)? – I’m fine.)')								
+					});
+				});
+			});
 		})
     });
 })

--- a/vicav.xqm
+++ b/vicav.xqm
@@ -237,7 +237,7 @@ declare
 function vicav:get_lingfeatures($ana as xs:string*, $expl as xs:string*, $xsltfn as xs:string) {
     
     let $ns := "declare namespace tei = 'http://www.tei-c.org/ns/1.0';"
-    let $q := 'collection("vicav_lingfeatures")//tei:cit[@type="featureSample" and (.//tei:w[contains-token(@ana,"' || $ana || '")][1] || .//tei:phr[contains-token(@ana,"#' || $ana || '")][1])]'
+    let $q := 'collection("vicav_lingfeatures")//tei:cit[@type="featureSample" and (.//tei:w[contains-token(@ana,"' || $ana || '")][1] || .//tei:phr[contains-token(@ana,"' || $ana || '")][1])]'
     let $query := $ns || $q    
     let $results := xquery:eval($query)
     
@@ -253,7 +253,7 @@ function vicav:get_lingfeatures($ana as xs:string*, $expl as xs:string*, $xsltfn
     let $style := doc($stylePath)
     let $sHTML := xslt:transform-text($ress1, $style, map {"highLightIdentifier":$ana,"explanation":$expl})
     
-    return
+    return 
         (:<div type="lingFeatures">{$sHTML}</div>:)
         (:$ress1:)
         $sHTML


### PR DESCRIPTION
Follow-up to the features explore view fix: the phrases still looked for the old hashmark-stype tags. Added test for this case as well.