### PR TITLE
Add informant metadata to samples view

### DIFF
--- a/cypress/fixtures/sampletexts.json
+++ b/cypress/fixtures/sampletexts.json
@@ -30,6 +30,9 @@
 		"variants": {
 			"ḥbastu": "ⁱbṭītu",
 			"masǟ": "Standard Arabic",
-		}
+		},
+		"person": "Test1",
+		"age": 20,
+		"sex": "m"
 	}
 }

--- a/cypress/fixtures/sampletexts.json
+++ b/cypress/fixtures/sampletexts.json
@@ -1,7 +1,7 @@
 {
 	"Tunis": {
-		"labels": ["Tunis"],
-		"snippetid": "tunis_sample_01",
+		"labels": ["Tunis2"],
+		"snippetid": "tunis2_sample_01",
 		"sentences": [
 			"nhāṛ li-ṯnīn baʕd il-fažr əmšīt l-is-sūq bāš nišri ʕ9am w-xu9ṛa kīma bītinžāl w-ṯūm.",
 			"šrīt zūz kīlu buṛdgāna b-dīnāṛ zāda.",

--- a/cypress/fixtures/vicav_samples/sampletexts.xml
+++ b/cypress/fixtures/vicav_samples/sampletexts.xml
@@ -19,7 +19,1718 @@
             <p>This is an original digital text</p>
          </sourceDesc>
       </fileDesc>
-   </teiHeader><TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:file="http://expath.org/ns/file" xml:id="test_sample_01">
+   </teiHeader>
+   <TEI xml:id="tunis2_sample_01">
+      <teiHeader>
+         <fileDesc>
+            <titleStmt>
+               <title>Short sample text of Tunis2 Arabic</title>
+               <author>Ines Dallaji</author>
+            </titleStmt>
+            <publicationStmt>
+               <publisher>ACDH-OeAW</publisher>
+               <pubPlace>Vienna</pubPlace>
+               <date>2018-03-21</date>
+               <availability status="restricted">
+                  <p>
+                     <ref type="license" target="http://creativecommons.org/licenses/by-nc-sa/3.0/"/>
+                  </p>
+               </availability>
+            </publicationStmt>
+            <sourceDesc>
+               <p>This is an original digital text</p>
+            </sourceDesc>
+         </fileDesc>
+      </teiHeader>
+      <text>
+         <body>
+            <head xml:space="preserve">Short sample text of <name xml:lang="eng">Tunis2</name> Arabic</head>
+            <div type="positioning">
+               <p>
+                  <geo>36.81, 10.19</geo>
+               </p>
+            </div>
+            <div type="sampleText">
+               <p>
+                  <s n="1">
+                     <w>
+                        <fs>
+                           <f name="wordform">nhāṛ </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">li</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ṯnīn </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">baʕd </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">il</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">fažr </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">əmšīt </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">l</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">is</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">sūq </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nišri </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ʕ9am </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">xu9ṛa </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">kīma </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bītinžāl </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ṯūm</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="2">
+                     <w>
+                        <fs>
+                           <f name="wordform">šrīt </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">zūz </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">kīlu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">buṛdgāna </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">b</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">dīnāṛ </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">zāda</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="3">
+                     <w>
+                        <fs>
+                           <f name="wordform">mā</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">xḏīt</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">š </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ṭmāṭim </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">cla </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">xāṭir </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">kānit </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ġālya </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">baṛša</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="4">
+                     <w>
+                        <fs>
+                           <f name="wordform">tʕaddīt </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">baḥḏa </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">xūya </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">li</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">kbīr</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">,</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform"> </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">baʕd </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">xḏīt </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">tāksi </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">rawwaḥt </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">li</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">d</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">dāṛ </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">qbal </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nuṣṣ </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">in</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nhāṛ</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="5">
+                     <w>
+                        <fs>
+                           <f name="wordform">baʕd </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">šwayya </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">žāu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">z</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">zġāṛ </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">m</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">il</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">maktab </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">klīna </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">xubz </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">lūbya</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="6">
+                     <w>
+                        <fs>
+                           <f name="wordform">baʕd </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">li</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">fṭūr </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">shalthum</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">:</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform"> </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">„āš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">taʕmlu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">f</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">il</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">līl</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">?</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">“ </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="7">
+                     <w>
+                        <fs>
+                           <f name="wordform">qālūli</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">:</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform"> </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">„il</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">yūm </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nuquʕdu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">fi</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">d</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">dāṛ</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">,</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform"> </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">āma/amma/lākin </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ġudwa </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nḥibbu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nqāblu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ṣḥābna</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="8">
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nimšīu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">mʕāhum </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">il</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">wild </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ʕammna </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">lli </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">yuskun </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">f</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ir</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">Ryāna</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="9">
+                     <w>
+                        <fs>
+                           <f name="wordform">ġādi </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">nušuṛbu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">qahwa </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">naḥkīu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">šwayya</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.“</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+                  <s n="10">
+                     <w>
+                        <fs>
+                           <f name="wordform">āna </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">qutt</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ilhum</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">:</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform"> </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">„bāhi</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">,</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform"> </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">āma/amma/lākin </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">mā</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">tinsāū</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">š </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">thizzu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">buṛṭāblūwāt-kum </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">w</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">-</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">kallmū-ni </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">īḏa </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">kān </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">bāš </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">tžīu </f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">ṃṃaxxaṛ</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">.</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                     <w>
+                        <fs>
+                           <f name="wordform">“</f>
+                           <f name="pos"/>
+                           <f name="lemma"/>
+                           <f name="translation"/>
+                           <f name="other"/>
+                        </fs>
+                     </w>
+                  </s>
+               </p>
+            </div>
+            <div type="dvTranslations">
+               <p>
+                  <s type="translationSentence" n="1">Am Montag nach der Morgendämmerung ging ich
+                     zum Markt, um Eier und Gemüse wie Melanzani und Knoblauch zu kaufen. </s>
+                  <s type="translationSentence" n="2">Ich kaufte auch 2 Kilo Orangen um 1 Dinar. </s>
+                  <s type="translationSentence" n="3">Tomaten nahm ich keine, weil sie sehr teuer
+                     waren. </s>
+                  <s type="translationSentence" n="4">Ich schaute noch bei meinem älteren Bruder
+                     vorbei, dann nahm ich ein Taxi und kehrte vor Mittag nach Hause zurück. </s>
+                  <s type="translationSentence" n="5">Kurz darauf kamen die Kinder aus der Schule
+                     und wir aßen Brot und Bohnen. </s>
+                  <s type="translationSentence" n="6">Nach dem Mittagessen fragte ich sie: „Was
+                     werdet ihr am Abend machen?“ </s>
+                  <s type="translationSentence" n="7">Sie sagten zu mir: „Heute bleiben wir zu
+                     Hause, aber morgen möchten wir unsere Freunde treffen. </s>
+                  <s type="translationSentence" n="8">Wir werden mit ihnen zu unserem Cousin, der im
+                     Viertel ir-Ryāna wohnt, gehen. </s>
+                  <s type="translationSentence" n="9">Dort werden wir Kaffee trinken und uns
+                     unterhalten.“ </s>
+                  <s type="translationSentence" n="10">Ich sagte zu ihnen: „Gut, aber vergesst nicht
+                     eure Handys mitzunehmen und ruft mich an, falls ihr euch verspätet.</s>
+               </p>
+            </div>
+         </body>
+      </text>
+   </TEI>
+
+   <TEI xmlns:tei="http://www.tei-c.org/ns/1.0" xmlns:file="http://expath.org/ns/file" xml:id="test_sample_01">
    <teiHeader>
       <fileDesc>
          <titleStmt>

--- a/cypress/fixtures/vicav_samples/sampletexts.xml
+++ b/cypress/fixtures/vicav_samples/sampletexts.xml
@@ -42,7 +42,7 @@
       </fileDesc>
       <profileDesc>
          <particDesc>
-            <person sex="m" age="20" role="unknown"/>
+            <person sex="m" age="20">Test1</person>
          </particDesc>
       </profileDesc>
    </teiHeader>

--- a/cypress/integration/sampletexts_spec.js
+++ b/cypress/integration/sampletexts_spec.js
@@ -7,6 +7,13 @@ let checksampleTexts = function(fixture, label) {
         cy.get('img[alt="'+ fixture.labels[l] + '"]').click({force: true});
     }
 
+    if (fixture.person !== undefined) {
+        cy.get('[data-snippetid=' + fixture.snippetid + '] i').as('snippet')
+        cy.get('@snippet').contains(fixture.person);
+        cy.get('@snippet').contains(fixture.sex)
+        cy.get('@snippet').contains(fixture.age);
+    }
+
     cy.get('[data-snippetid=' + fixture.snippetid + '] .spSentence').as('sentences')
 
     cy.get('@sentences').then((sentences) => {

--- a/js/geo_data.js
+++ b/js/geo_data.js
@@ -56,6 +56,7 @@ function insertFeatureMarkers() {
                     loc = loc.replace(/′W/g, "");
                 }
                 
+
                 sTooltip = $(this).find('alt').text();
                 sID = $(this).attr('xml:id');
                 //console.log(loc + ' ' + sAlt);

--- a/vicav.xqm
+++ b/vicav.xqm
@@ -722,14 +722,16 @@ declare
 function vicav:get_feature_markers() {
     let $entries := collection('vicav_lingfeatures')//tei:TEI
     let $out :=
-    for $item in $entries
-    return
-        <r
-            type='geo'>{$item/@xml:id}
-            <loc>{$item//tei:geo/text()}</loc>
-            <alt>{$item//tei:head[1]/tei:name[1]/text()}</alt>
-            <freq>1</freq>
-        </r>
+        for $item in $entries
+            return
+                if ($item/@xml:id and $item//tei:geo/text()) then
+                <r
+                    type='geo'>{$item/@xml:id}
+                    <loc>{$item//tei:geo/text()}</loc>
+                    <alt>{$item//tei:head[1]/tei:name[1]/text()}</alt>
+                    <freq>1</freq>
+                </r>
+                else ''
     
     return
         <rs>{$out}</rs>

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -16,6 +16,11 @@
             <p>By&#160;<i><xsl:value-of select="//tei:author"/>
                 <xsl:if test="//tei:publicationStmt/tei:date">&#160;(<xsl:value-of select="//tei:publicationStmt/tei:date"/>)</xsl:if>
             </i></p>
+            <xsl:if test="//tei:profileDesc/tei:particDesc/tei:person/text()">
+                <p>Informant ID: 
+                    <i><xsl:value-of select="//tei:profileDesc/tei:particDesc/tei:person"/></i><xsl:if test="//tei:profileDesc/tei:particDesc/tei:person/@sex">, Sex: <i><xsl:value-of select="//tei:profileDesc/tei:particDesc/tei:person/@sex"/></i></xsl:if><xsl:if test="//tei:profileDesc/tei:particDesc/tei:person/@age">, Age: <i><xsl:value-of select="//tei:profileDesc/tei:particDesc/tei:person/@age"/></i></xsl:if>
+                </p>
+            </xsl:if>
             
             <xsl:if test="string-length(//tei:teiHeader/tei:profileDesc/tei:particDesc/tei:p[1])&gt;0">
                 <xsl:for-each select="//tei:teiHeader/tei:profileDesc/tei:particDesc/tei:p">


### PR DESCRIPTION
Sample texts are now displaying the SpeakerID/gender/age format below the publishing information.

+ test (in sampletests_spec.js)
+ test fixes (feature markers should just ignore non-TEI data in the database), sample tests should have separate fixtures for each sample.