### PR TITLE
Self-updating pages support and print view links

### DIFF
--- a/vicav.xqm
+++ b/vicav.xqm
@@ -392,10 +392,11 @@ declare
 %rest:path("/vicav/ling_feature")
 %rest:GET
 %rest:query-param("id", "{$id}")
+%rest:query-param("print", "{$print}")
 %test:arg("id", "ling_features_baghdad")
-function vicav:get_ling_feature($id as xs:string?) {
+function vicav:get_ling_feature($id as xs:string?, $print as xs:string*) {
   api-problem:or_result (prof:current-ns(),
-    vicav:_get_profile#6, ['vicav_lingfeatures', $id, 'features_01.xslt', (), false(), '/ling_feature'], map:merge((cors:header(()), vicav:return_content_header())))
+    vicav:_get_profile#6, ['vicav_lingfeatures', $id, 'features_01.xslt', $print, false(), '/ling_feature'], map:merge((cors:header(()), vicav:return_content_header())))
 };
 
 declare function vicav:_get_profile($coll as xs:string, $id as xs:string*,
@@ -404,7 +405,10 @@ declare function vicav:_get_profile($coll as xs:string, $id as xs:string*,
   vicav:transform(collection($coll || vicav:get_project_db())/descendant::tei:TEI[@xml:id=$id],
      $xsltfn, $print, map{
           'param-base-path': replace(util:get-base-uri-public(), $endpoint, ''),
-          'tei-link-marker': xs:string($generateTeiMarker)
+          'tei-link-marker': xs:string($generateTeiMarker),
+          "print-url": concat(
+             request:uri(), "?", request:query(), "&amp;print=true" 
+          )
         }
      )
 };
@@ -427,7 +431,11 @@ function vicav:get_sample($coll as xs:string*, $id as xs:string*, $xsltfn as xs:
     let $results := xquery:eval($query)
     return 
         (web:response-header(map {'method': 'basex'}, map:merge((cors:header(()), vicav:return_content_header()))),
-        vicav:transform($results, $xsltfn, $print, map{}))
+        vicav:transform($results, $xsltfn, $print, map{
+            "print-url": concat(
+                request:uri(), "?", request:query(), "&amp;print=true" 
+            )
+        }))
 };
 
 
@@ -688,7 +696,10 @@ function vicav:explore_samples(
             "filter-words": string($word),
             "filter-features":$filter_features,
             "filter-translations": $trans_filter,
-            "filter-comments": $comment_filter
+            "filter-comments": $comment_filter,
+            "print-url": concat(
+                request:uri(), "?", request:query(), "&amp;print=true" 
+            )
         })
 
     return

--- a/xslt/cross_features_02.xslt
+++ b/xslt/cross_features_02.xslt
@@ -55,7 +55,15 @@
             <div>
                 <table class="tbHeader">
                     <tr><td>
-                        <h2 xml:space="preserve">Compare features</h2></td><td class="tdPrintLink"><a href="#" data-print="true" class="aTEIButton">Print</a></td>
+                        <h2 xml:space="preserve">Compare features</h2></td>
+                        <td class="tdPrintLink">
+                            <a data-print="true" target="_blank" class="aTEIButton">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="$print-url"/>
+                                </xsl:attribute>
+                                Print
+                            </a>
+                        </td>
                     </tr>
                     <!-- <tr><td><i>
                             <xsl:value-of select="string-join(distinct-values(.//item/@city), ', ')"/></i>

--- a/xslt/cross_samples_01.xslt
+++ b/xslt/cross_samples_01.xslt
@@ -50,8 +50,14 @@ version="3.1">
                 <table class="tbHeader">
                     <tr><td>
                         <h2 xml:space="preserve">Compare samples</h2></td>
-                        <td class="tdPrintLink"><a href="#" data-print="true" class="aTEIButton">Print</a></td>
-                    </tr>
+                            <td class="tdPrintLink">
+                            <a data-print="true" target="_blank" class="aTEIButton">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="$print-url"/>
+                                </xsl:attribute>
+                                Print
+                            </a>
+                        </td>                    </tr>
                 </table>
                 <div class="explore-samples-summary">
                     <h4>Summary</h4>
@@ -71,16 +77,18 @@ version="3.1">
                 </div>
                 
                 <xsl:if test="$filter-features">
-                    <div class="sentences-nav">
+                    <div class="sentences-nav flex justify-between">
                         <xsl:if test="not($prev_sentence = '')">
-                            <a href="#" data-feature="{$prev_sentence}" class="prev-link"><i class="fa fa-chevron-left"><span/></i> Previous</a>
+                            <a href="#" data-target-type="ExploreSamples" data-target-window="self" data-features="{$prev_sentence}" class="prev-link"><i class="fa fa-chevron-left"><span/></i> Previous</a>
                         </xsl:if>
+                        <form>
+                            <input name="features" data-target-type="ExploreSamples" data-target-window="self">
+                                <xsl:attribute name="value"><xsl:value-of select="string-join($selected-sentences, ',')"/></xsl:attribute>
+                            </input> / <xsl:value-of select="max($all-sentences)"/>
+                        </form>
                         <xsl:if test="not($next_sentence = '')">
-                            <a href="#" data-feature="{$next_sentence}" class="next-link">Next <i class="fa fa-chevron-right"><span/></i></a>
+                            <a href="#" data-target-type="ExploreSamples" data-target-window="self" data-features="{$next_sentence}" class="next-link">Next <i class="fa fa-chevron-right"><span/></i></a>
                         </xsl:if>
-                        <input name="sentences">
-                            <xsl:attribute name="value"><xsl:value-of select="string-join($selected-sentences, ',')"/></xsl:attribute>
-                        </input> / <xsl:value-of select="max($all-sentences)"/>
                     </div>
                 </xsl:if>
 

--- a/xslt/features_01.xslt
+++ b/xslt/features_01.xslt
@@ -18,13 +18,36 @@
               <xsl:choose>
                 <xsl:when test="$tei-link-marker = 'true'">
                 <table class="tbHeader">
-                    <tr><td><h2><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/></h2></td><td class="tdTeiLink">{teiLink}</td><td class="tdPrintLink">
-                <a href="#" data-print="true" class="aTEIButton"><xsl:attribute name="data-featurelist"><xsl:value-of 
-                    select="./@xml:id"/></xsl:attribute>Print</a></td></tr>
+                    <tr>
+                        <td><h2><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/></h2></td>
+                        <td class="tdTeiLink">{teiLink}</td>
+                        <td class="tdPrintLink">
+                            <a data-print="true" target="_blank" class="aTEIButton">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="$print-url"/>
+                                </xsl:attribute>
+                                Print
+                            </a>
+                        </td>
+                    </tr>
                 </table>
                 </xsl:when>
                 <xsl:otherwise>
-                  <h2><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/></h2>
+                  <table class="tbHeader">
+                    <tr>
+                        <td>
+                            <h2><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:title"/></h2>
+                        </td>
+                        <td class="tdPrintLink">
+                            <a data-print="true" target="_blank" class="aTEIButton">
+                                <xsl:attribute name="href">
+                                    <xsl:value-of select="$print-url"/>
+                                </xsl:attribute>
+                                Print
+                            </a>
+                        </td>
+                    </tr>
+                  </table>
                 </xsl:otherwise>
               </xsl:choose>
 

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -10,9 +10,17 @@
     <xsl:template match="tei:TEI">        
         <div>
             <table class="tbHeader">
-                <tr><td><h2><xsl:value-of select="./tei:text/tei:body/tei:head"/></h2></td><td class="tdTeiLink">{teiLink}</td><td class="tdPrintLink">
-                <a href="#" data-print="true" class="aTEIButton"><xsl:attribute name="data-sampletext"><xsl:value-of 
-                    select="./@xml:id"/></xsl:attribute>Print</a></td></tr>
+                <tr><td><h2><xsl:value-of select="./tei:text/tei:body/tei:head"/></h2></td>
+                    <xsl:if test="$tei-link-marker='true'"><td class="tdTeiLink">{teiLink}</td></xsl:if>
+                    <td class="tdPrintLink">
+                        <a data-print="true" target="_blank" class="aTEIButton">
+                            <xsl:attribute name="href">
+                                <xsl:value-of select="$print-url"/>
+                            </xsl:attribute>
+                            Print
+                        </a>
+                    </td>
+                </tr>
             </table>
 
             <p xml:space="preserve">By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="(./tei:teiHeader/tei:revisionDesc/tei:change[1]/@n, replace(./tei:teiHeader/tei:revisionDesc/tei:change[1]/@when, 'T.*', ''))[1]" />)</xsl:if></i></p>

--- a/xslt/sampletexts_common.xslt
+++ b/xslt/sampletexts_common.xslt
@@ -12,7 +12,8 @@ version="3.1">
 <xsl:variable name="images-base-path" select="tei:concat-path('images')"/>
 <xsl:variable name="docs-base-path" select="tei:concat-path('')"/>
 <xsl:param name="highlight" select="()"></xsl:param>
-    
+<xsl:param name="print-url" as="xs:string" select="''"></xsl:param>
+
 <xsl:template match="//tei:div[@type='sampleText']/tei:p/tei:s | //tei:div[@type='corpusText']/tei:u">
     <span class="spSentence">
         <xsl:attribute name="xml:space">preserve</xsl:attribute>      
@@ -235,6 +236,7 @@ version="3.1">
     <xsl:param name="type"></xsl:param>
     <xsl:param name="position"></xsl:param>
     <xsl:param name="highLightIdentifier"/>
+
     <xsl:variable name="wordform" select="acdh:get-wordform($w)"/>
     <xsl:variable name="add-space" select="not(matches($wordform, '^[„-]$')) and
         not($w/following-sibling::*[1]/name() = 'pc') and


### PR DESCRIPTION
* Add data-target-window="self" to nnext and previous page links on explore samples results page.
* Support print view links in sample texts, samples/features comparison view, feature lists