### PR TITLE
Fix multiple revisions

### DIFF
--- a/vicav.xqm
+++ b/vicav.xqm
@@ -1947,9 +1947,10 @@ declare function vicav:_get_data_words($type as xs:string*) {
     let $persons := if ($type = 'samples') then 
         for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:teiCorpus/tei:TEI/tei:text/tei:body/tei:div[@type="sampleText"]/tei:p/tei:s//tei:w/tei:fs/tei:f[@name="wordform"]/text()
         return replace(normalize-space($w), '[\s&#160;]', '')
-    else for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:TEI/tei:text/tei:body/tei:div/tei:div[@type="featureGroup"]/tei:cit[@type="featureSample"]/tei:quote//tei:w/tei:fs/tei:f[@name="wordform"]/text()
+    else if ($type = "features") then for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:TEI/tei:text/tei:body/tei:div/tei:div[@type="featureGroup"]/tei:cit[@type="featureSample"]/tei:quote//tei:w/tei:fs/tei:f[@name="wordform"]/text()
        return replace(normalize-space($w), '[\s&#160;]', '')
-
+    else for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:TEI/tei:text/tei:body/tei:div/tei:annotationBlock/tei:u/tei:w
+        return replace(normalize-space($w), '[\s&#160;]', '')
     let $out :=
     for $person in distinct-values($persons)
         order by $person

--- a/vicav.xqm
+++ b/vicav.xqm
@@ -1926,31 +1926,56 @@ function vicav:get_sample_persons($type as xs:string*) {
         <persons>{$out}</persons>)
 };
 
+declare function vicav:tr($string as xs:string) {
+    let $tr := translate($string, 
+        "ᵃᵉⁱᵒᵘᵊʰʷʸˢᶴQāēīōūḅṭḍṣẓḏšžṛḥṃǧġʕʔ",
+        "aeiouehwyssqaeioubtdszdszrhmgg??"
+    )
+    return replace(
+        replace($tr, "ǟ", "a"), "ḏ̣", "d")
+};
+
 declare
 %rest:path("/vicav/data_words")
 %rest:query-param("type", "{$type}")
+%rest:query-param("query", "{$query}")
 %rest:GET
 %rest:produces("application/xml")
 %rest:produces("application/json")
 %rest:produces('application/problem+json')   
 %rest:produces('application/problem+xml')
-function vicav:get_data_words($type as xs:string*) {
+function vicav:get_data_words($type as xs:string*, $query as xs:string*) {
     api-problem:or_result (prof:current-ns(),
-    vicav:_get_data_words#1, [$type], map:merge((cors:header(()), vicav:return_content_header()))
+    vicav:_get_data_words#2, [$type, $query], map:merge((cors:header(()), vicav:return_content_header()))
   )
 };
 
-declare function vicav:_get_data_words($type as xs:string*) {
+declare function vicav:_get_data_words($type as xs:string*, $query as xs:string*) {
     let $accept-header := try { request:header("ACCEPT") } catch basex:http { 'application/xhtml+xml' }
-    let $type := if ($type = () or $type = '') then 'samples' else $type
+    let $collections := if (empty($type) or $type = '') then 
+        <i><coll>samples</coll><coll>corpus</coll><coll>lingfeatures</coll></i> else <i><coll>{$type}</coll></i>
+    
+     let $words := for $collName in $collections[1]/coll/text()
+        let $collection := collection("vicav_" || $collName || vicav:get_project_db())
+        let $base := if ($collName = "samples") then 
+            $collection/tei:teiCorpus/tei:TEI/tei:text/tei:body/tei:div[@type="sampleText"]/tei:p/tei:s
+            else if ($collName = "lingfeatures") then
+            $collection/tei:TEI/tei:text/tei:body/tei:div/tei:div[@type="featureGroup"]/tei:cit[@type="featureSample"]/tei:quote
+            else $collection/tei:TEI/tei:text/tei:body/tei:div/tei:annotationBlock/tei:u/tei:w
+        
+        return if ($collName = ["samples", "lingfeatures"]) then
+            (
+                $base/tei:choice/tei:w/tei:fs/tei:f[if (empty($query)) then @name="wordform" else @name = "wordform" and contains(vicav:tr(./text()), vicav:tr($query))]/text(),
+                $base/tei:choice/tei:phr/tei:w/tei:fs/tei:f[if (empty($query)) then @name="wordform" else @name = "wordform" and contains(vicav:tr(./text()), vicav:tr($query))]/text(),                
+                $base/tei:w/tei:fs/tei:f[if (empty($query)) then @name="wordform" else @name = "wordform" and contains(vicav:tr(./text()), vicav:tr($query))]/text(),
+                $base/tei:phr/tei:w/tei:fs/tei:f[if (empty($query)) then @name="wordform" else @name = "wordform" and contains(vicav:tr(./text()), vicav:tr($query))]/text()
+            )
+            else 
+                $base[if (empty($query)) then true() else contains(vicav:tr(.), vicav:tr($query))]
 
-    let $persons := if ($type = 'samples') then 
-        for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:teiCorpus/tei:TEI/tei:text/tei:body/tei:div[@type="sampleText"]/tei:p/tei:s//tei:w/tei:fs/tei:f[@name="wordform"]/text()
+    let $persons := for $w in $words
         return replace(normalize-space($w), '[\s&#160;]', '')
-    else if ($type = "features") then for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:TEI/tei:text/tei:body/tei:div/tei:div[@type="featureGroup"]/tei:cit[@type="featureSample"]/tei:quote//tei:w/tei:fs/tei:f[@name="wordform"]/text()
-       return replace(normalize-space($w), '[\s&#160;]', '')
-    else for $w in collection('vicav_' || $type || vicav:get_project_db())/tei:TEI/tei:text/tei:body/tei:div/tei:annotationBlock/tei:u/tei:w
-        return replace(normalize-space($w), '[\s&#160;]', '')
+
     let $out :=
     for $person in distinct-values($persons)
         order by $person
@@ -1965,7 +1990,7 @@ declare function vicav:_get_data_words($type as xs:string*) {
         'xslt/data_words-json.xslt')
         return serialize($renderedJson, map {"method": "json", "indent": "no"})
     else 
-        <words>{$out}</words>
+        <words>{$out}</words> 
 };
 
 

--- a/xslt/features_01.xslt
+++ b/xslt/features_01.xslt
@@ -50,8 +50,7 @@
                   </table>
                 </xsl:otherwise>
               </xsl:choose>
-
-                <p xml:space="preserve">By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(./tei:teiHeader/tei:revisionDesc/tei:change[1]/@when, 'T.*', '')" />)</xsl:if></i></p>
+                <p xml:space="preserve">By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', '')" />)</xsl:if></i></p>
                 
                 <ul id="informants"><xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person"><li xml:space="preserve">Informant ID: <i><xsl:value-of 
                     select="."/></i><xsl:if

--- a/xslt/profile_01.xslt
+++ b/xslt/profile_01.xslt
@@ -335,7 +335,12 @@
     <xsl:template match="tei:div[@type=['sampleText', 'lingFeatures', 'bibliography']]">
         <xsl:if test="count(./tei:p/tei:ref) > 0">
             <xsl:copy>
-                <xsl:apply-templates/>
+                <xsl:apply-templates select="./tei:head"/>
+                <xsl:copy select="./tei:p">
+                    <xsl:apply-templates select="./tei:ref">
+                        <xsl:sort select="number(replace(./text(), '([a-zA-Z]+)(\d+)/.+', '$2'))" data-type="number" order="ascending"/>
+                    </xsl:apply-templates>
+                </xsl:copy>
             </xsl:copy>
         </xsl:if>
     </xsl:template>

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -23,7 +23,12 @@
                 </tr>
             </table>
 
-            <p xml:space="preserve">By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="(./tei:teiHeader/tei:revisionDesc/tei:change[1]/@n, replace(./tei:teiHeader/tei:revisionDesc/tei:change[1]/@when, 'T.*', ''))[1]" />)</xsl:if></i></p>
+            <p xml:space="preserve">
+            By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/>
+            <xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> 
+            (revision: <xsl:value-of 
+            select="(./tei:teiHeader/tei:revisionDesc[1]/tei:change[1]/@n, replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', ''))[1]" />)
+            </xsl:if></i></p>
             <ul id="informants">
             <xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person">
                 <li xml:space="preserve">Informant ID: 

--- a/xslt/teiCorpusTeiHeader-json.xslt
+++ b/xslt/teiCorpusTeiHeader-json.xslt
@@ -69,6 +69,12 @@
             <xsl:apply-templates select="t:person" mode="arrayItem"/>
         </listPerson>
     </xsl:template>
+
+    <xsl:template match="t:particDesc">
+        <particDesc type="array">
+            <xsl:apply-templates select="t:person" mode="arrayItem"/>
+        </particDesc>
+    </xsl:template>
     
     <xsl:template match="t:*" mode="arrayItem">
         <_ type="object">

--- a/xslt/teiCorpusTeiHeader-json.xslt
+++ b/xslt/teiCorpusTeiHeader-json.xslt
@@ -69,12 +69,6 @@
             <xsl:apply-templates select="t:person" mode="arrayItem"/>
         </listPerson>
     </xsl:template>
-
-    <xsl:template match="t:particDesc">
-        <particDesc type="array">
-            <xsl:apply-templates select="t:person" mode="arrayItem"/>
-        </particDesc>
-    </xsl:template>
     
     <xsl:template match="t:*" mode="arrayItem">
         <_ type="object">


### PR DESCRIPTION
* There was an error when multiple change tags were preset.
* Support search in words for autocomplete widget, also add support for distinct corpus words.
* Add vicav:tr() function for diactritics-insensitive word search (currently used in autocomplete)