### PR TITLE
Adapt to new person and author data structure that matches that of corpus files

### DIFF
--- a/fixtures/vicav_lingfeatures/vicav_lingfeatures_test2_toks.xml
+++ b/fixtures/vicav_lingfeatures/vicav_lingfeatures_test2_toks.xml
@@ -36,7 +36,9 @@
       </encodingDesc>
       <profileDesc>
          <particDesc>
-            <person sex="f" age="45">Test1</person>
+            <listPerson>
+              <person sex="f" age="45">Test1</person>
+            </listPerson>
          </particDesc>
          <settingDesc>
             <place>

--- a/fixtures/vicav_lingfeatures/vicav_lingfeatures_test_toks.xml
+++ b/fixtures/vicav_lingfeatures/vicav_lingfeatures_test_toks.xml
@@ -29,7 +29,9 @@
       </encodingDesc>
       <profileDesc>
          <particDesc>
-            <person sex="f" age="45">Tunis2</person>
+            <listPerson>
+              <person sex="f" age="45">Tunis2</person>
+            </listPerson>
          </particDesc>
          <settingDesc>
             <place>

--- a/fixtures/vicav_samples/sampletexts.xml
+++ b/fixtures/vicav_samples/sampletexts.xml
@@ -1736,7 +1736,9 @@
       </fileDesc>
       <profileDesc>
          <particDesc>
-            <person sex="m" age="20">Test1</person>
+           <listPerson>
+              <person sex="m" age="20">Test1</person>
+           </listPerson>
          </particDesc>
          <settingDesc>
             <place>
@@ -3188,7 +3190,9 @@
       </fileDesc>
       <profileDesc>
          <particDesc>
-            <person sex="f" age="40">Test2</person>
+            <listPerson>
+              <person sex="f" age="40">Test2</person>
+            </listPerson>
          </particDesc>
          <settingDesc>
             <place>

--- a/vicav.xqm
+++ b/vicav.xqm
@@ -572,7 +572,7 @@ declare function vicav:explore-query(
             return "'" || $p || "'" 
 
     let $person_q := if (not(empty($ps))) then
-        '(./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person/text() = ['|| string-join($ps, ',') ||'])'
+        '(./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person/text() = ['|| string-join($ps, ',') ||'])'
         else ''
 
     let $words_q := for $w in tokenize($word, ',')
@@ -593,8 +593,8 @@ declare function vicav:explore-query(
 
     let $age_q := if (not(empty($age_bounds)) and ($age_bounds[2] != "100" or $age_bounds[1] != "0")) then
         vicav:and((
-            '(number(./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age) > ' || min($age_bounds) || ')',
-            ' (number(./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age) < ' || max($age_bounds) || ')'
+            '(number(./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age) > ' || min($age_bounds) || ')',
+            ' (number(./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age) < ' || max($age_bounds) || ')'
         ))
         else ''
 
@@ -604,7 +604,7 @@ declare function vicav:explore-query(
         else ()
 
     let $sex_q := if (not(empty($sex_qqs))) then
-        ' (./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person/@sex = [' || string-join($sex_qqs, ',') || '])'
+        ' (./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person/@sex = [' || string-join($sex_qqs, ',') || '])'
         else ''
 
     let $loc_qs := tokenize($location, ',')
@@ -661,9 +661,9 @@ declare function vicav:explore-data(
     let $ress :=
       for $item in $results
         let $city := $item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:settlement/tei:name[@xml:lang="en"]/text()
-        let $informant := $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text()
-        let $age := $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age
-        let $sex := $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@sex
+        let $informant := $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text()
+        let $age := $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age
+        let $sex := $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@sex
 
         return
            <item city="{$city}" informant="{$informant}" age="{$age}" sex="{$sex}">{$item}</item>
@@ -1106,9 +1106,9 @@ declare function vicav:_get_compare(
                     for $i in $item-in-region
                     return 
                         <item xml:id="{vicav:get-root($i)/@xml:id}" 
-                        informant="{vicav:get-root($i)/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]}" 
-                        age="{vicav:get-root($i)/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age}" 
-                        sex="{vicav:get-root($i)/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@sex}" 
+                        informant="{vicav:get-root($i)/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]}" 
+                        age="{vicav:get-root($i)/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age}" 
+                        sex="{vicav:get-root($i)/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@sex}" 
                         >{$i}{
                             if ($resourcetype = "samples") then
                             $i/../../../tei:div[@type="dvTranslations"]/tei:p/tei:s[@n = $i/@n] 
@@ -1843,10 +1843,10 @@ declare function vicav:_get_sample_markers() {
         let $loc := if ($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:location/tei:geo/text()) then 
                         replace($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:location/tei:geo/text(), '(\d+(\.|,)\s*\d+,\s*\d+(\.|,)\s*\d+).*', '$1')
                     else $item/tei:text/tei:body/tei:div[@type="positioning"]//tei:geo/text()
-        let $alt := if ($item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person)
-        then $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text() || '/' ||
-         $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@sex || '/' ||
-         $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age
+        let $alt := if ($item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person)
+        then $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text() || '/' ||
+         $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@sex || '/' ||
+         $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age
         else  $item/tei:text/tei:body/tei:head/tei:name[1]
 
         let $locName := if ($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:settlement) then
@@ -1912,7 +1912,7 @@ declare
 function vicav:get_sample_persons($type as xs:string*) {
     let $type := if ($type = () or $type = '') then 'samples' else $type
 
-    let $persons := collection('vicav_' || $type || vicav:get_project_db())/descendant::tei:TEI/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person
+    let $persons := collection('vicav_' || $type || vicav:get_project_db())/descendant::tei:TEI/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person
     let $out :=
     for $person in $persons
         order by $person/text()
@@ -2016,10 +2016,10 @@ declare function vicav:_get_feature_markers() {
             let $loc := if ($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:location/tei:geo/text()) then 
                             replace($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:location/tei:geo/text(), '(\d+(\.|,)\s*\d+,\s*\d+(\.|,)\s*\d+).*', '$1')
                         else $item/tei:text/tei:body/tei:div[@type="positioning"]//tei:geo/text()
-            let $alt := if ($item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person)
-                then $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text() || '/' ||
-                 $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@sex || '/' ||
-                 $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age
+            let $alt := if ($item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person)
+                then $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text() || '/' ||
+                 $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@sex || '/' ||
+                 $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age
                 else  $item/tei:text/tei:body/tei:head/tei:name[1]
 
             let $locName := if ($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:settlement) then
@@ -2070,7 +2070,7 @@ declare function vicav:_get_all_data_markers() {
             let $loc := if ($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:location/tei:geo/text()) then
                             replace($item/tei:teiHeader/tei:profileDesc/tei:settingDesc/tei:place/tei:location/tei:geo/text(), '(\d+(\.|,)\s*\d+,\s*\d+(\.|,)\s*\d+).*', '$1')
                         else $item/tei:text/tei:body/tei:div[@type="positioning"]//tei:geo/text()
-            let $alt := if ($item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person) then $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text() || '/' || $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@sex || '/' || $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/@age else $locName
+            let $alt := if ($item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person) then $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text() || '/' || $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@sex || '/' || $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/@age else $locName
 
             return
                 if ($item/@xml:id and $loc) then
@@ -2113,12 +2113,12 @@ declare function vicav:data_list_region($type as xs:string, $region as xs:string
                             concat($cat, ': ', count($cat-items))
                         },
                         for $item in $cat-items
-                                order by $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text()
+                                order by $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text()
                                 return element p {
                                     element a {
                                         attribute href { '#' },
                                         attribute {$typestring} {$item/@xml:id},
-                                        text {$item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text()},
+                                        text {$item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text()},
                                         text { string-join((' (Revision: ', replace($item/tei:teiHeader/tei:revisionDesc/tei:change[1]/@when, 'T.*', ''), ')')) }
                                     }, element br {}
                                 }
@@ -2127,7 +2127,7 @@ declare function vicav:data_list_region($type as xs:string, $region as xs:string
 
                 (: Handle single type data list :)
                 else for $item in $city-items
-                                order by $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text()
+                                order by $item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text()
                                 let $typestring := switch($type)
                                     case 'lingfeatures' return
                                         'data-featurelist'
@@ -2139,7 +2139,7 @@ declare function vicav:data_list_region($type as xs:string, $region as xs:string
                                     element a {
                                         attribute href { '#' },
                                         attribute {$typestring} {$item/@xml:id},
-                                        text {$item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person[1]/text()},
+                                        text {$item/tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person[1]/text()},
                                         text { string-join((' (Revision: ', replace($item/tei:teiHeader/tei:revisionDesc/tei:change[1]/@when, 'T.*', ''), ')')) }
                                     }, element br {}
                                 }

--- a/xslt/features_01.xslt
+++ b/xslt/features_01.xslt
@@ -50,7 +50,7 @@
                   </table>
                 </xsl:otherwise>
               </xsl:choose>
-                <p xml:space="preserve">By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', '')" />)</xsl:if></i></p>
+                <p xml:space="preserve">By <i><xsl:value-of select="string-join(./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:respStmt/tei:persName, ',')"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', '')" />)</xsl:if></i></p>
                 
                 <ul id="informants"><xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person"><li xml:space="preserve">Informant ID: <i><xsl:value-of 
                     select="."/></i><xsl:if

--- a/xslt/features_01.xslt
+++ b/xslt/features_01.xslt
@@ -52,7 +52,7 @@
               </xsl:choose>
                 <p xml:space="preserve">By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', '')" />)</xsl:if></i></p>
                 
-                <ul id="informants"><xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person"><li xml:space="preserve">Informant ID: <i><xsl:value-of 
+                <ul id="informants"><xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person"><li xml:space="preserve">Informant ID: <i><xsl:value-of 
                     select="."/></i><xsl:if
                     test="@sex">, Sex: <i><xsl:value-of
                     select="@sex"/></i></xsl:if><xsl:if

--- a/xslt/features_01.xslt
+++ b/xslt/features_01.xslt
@@ -50,7 +50,7 @@
                   </table>
                 </xsl:otherwise>
               </xsl:choose>
-                <p xml:space="preserve">By <i><xsl:value-of select="string-join(./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:respStmt/tei:persName, ',')"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', '')" />)</xsl:if></i></p>
+                <p xml:space="preserve">By <i><xsl:value-of select="string-join(//tei:titleStmt/(tei:author, tei:respStmt/tei:persName), ',')"/><xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> (revision: <xsl:value-of select="replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', '')" />)</xsl:if></i></p>
                 
                 <ul id="informants"><xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person"><li xml:space="preserve">Informant ID: <i><xsl:value-of 
                     select="."/></i><xsl:if

--- a/xslt/profile_01.xslt
+++ b/xslt/profile_01.xslt
@@ -95,7 +95,7 @@
                     </tr>
                     <tr>
                         <td class="tdHead">Contributed by</td>
-                        <td class="tdProfileTableRight"><i><xsl:value-of select="string-join(./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:respStmt/tei:persName, ',')"/></i></td>
+                        <td class="tdProfileTableRight"><i><xsl:value-of select="string-join(//tei:titleStmt/(tei:author, tei:respStmt/tei:persName), ',')"/></i></td>
                     </tr>
                 </table>
             </div>

--- a/xslt/profile_01.xslt
+++ b/xslt/profile_01.xslt
@@ -95,7 +95,7 @@
                     </tr>
                     <tr>
                         <td class="tdHead">Contributed by</td>
-                        <td class="tdProfileTableRight"><i><xsl:value-of select="//tei:author"/></i></td>
+                        <td class="tdProfileTableRight"><i><xsl:value-of select="string-join(./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:respStmt/tei:persName, ',')"/></i></td>
                     </tr>
                 </table>
             </div>

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -24,7 +24,7 @@
             </table>
 
             <p xml:space="preserve">
-            By <i><xsl:value-of select="string-join(./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:respStmt/tei:persName, ',')"/>
+            By <i><xsl:value-of select="string-join(//tei:titleStmt/(tei:author,tei:respStmt/tei:persName), ',')"/>
             <xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> 
             (revision: <xsl:value-of 
             select="(./tei:teiHeader/tei:revisionDesc[1]/tei:change[1]/@n, replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', ''))[1]" />)

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -24,7 +24,7 @@
             </table>
 
             <p xml:space="preserve">
-            By <i><xsl:value-of select="./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:author"/>
+            By <i><xsl:value-of select="string-join(./tei:teiHeader/tei:fileDesc/tei:titleStmt/tei:respStmt/tei:persName, ',')"/>
             <xsl:if test="./tei:teiHeader/tei:revisionDesc/tei:change"> 
             (revision: <xsl:value-of 
             select="(./tei:teiHeader/tei:revisionDesc[1]/tei:change[1]/@n, replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', ''))[1]" />)

--- a/xslt/sampletext_01.xslt
+++ b/xslt/sampletext_01.xslt
@@ -30,7 +30,7 @@
             select="(./tei:teiHeader/tei:revisionDesc[1]/tei:change[1]/@n, replace(subsequence(./tei:teiHeader/tei:revisionDesc/tei:change/@when, 1, 1)[1], 'T.*', ''))[1]" />)
             </xsl:if></i></p>
             <ul id="informants">
-            <xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:person">
+            <xsl:for-each select="./tei:teiHeader/tei:profileDesc/tei:particDesc/tei:listPerson/tei:person">
                 <li xml:space="preserve">Informant ID: 
                     <i><xsl:value-of select="."/></i><xsl:if test="@sex">, Sex: <i><xsl:value-of select="@sex"/></i></xsl:if><xsl:if test="@age">, Age: <i><xsl:value-of select="@age"/></i></xsl:if>
                 </li>


### PR DESCRIPTION
PLs review if I don't break anything for other projects, but I would think these are all occurrences of feature lists and sample texts, which are only used heavily in Tunocent. Maybe Old Vicav data needs to be updated to reflect the listPerson element, but I am not sure about what vicav backend version it is using right now.