### PR TITLE
Harmonize initial panel elements syntax with menu

### DIFF
--- a/xslt/menu-json.xslt
+++ b/xslt/menu-json.xslt
@@ -50,8 +50,8 @@
     </xsl:template>
     
     <xsl:template match="frontpage">
-        <param><xsl:apply-templates select="param"/></param>
-        <panel><xsl:apply-templates select="panel"/></panel>
+      <param><xsl:apply-templates select="param"/></param>
+      <panel><xsl:apply-templates select="item"/></panel>
     </xsl:template>
     
     <xsl:template match="param">


### PR DESCRIPTION
Since panel and item is rendered equally I think it makes more sense to just use items everywhere.